### PR TITLE
Add pre-built hs-static-bin Docker images to ease the process to get an Haskell static binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ help:
 	@echo "Usage:"
 	@echo
 	@echo "   image            Build hs-static-bin Docker image"
+	@echo "   pull-image       Get pre-built hs-static-bin Docker image"
 	@echo "   show-env-vars    Show hs-static-bin environment variables settings"
 	@echo "   envrc            Create a .envrc for hs-static-bin environment variables"
 	@echo "   binary           Build an Haskell static binary"
@@ -21,6 +22,10 @@ image:
 	--build-arg BOOTSTRAP_HASKELL_GHC_VERSION=$(HASKELL_GHC_VERSION) \
 	--build-arg BOOTSTRAP_HASKELL_CABAL_VERSION=$(HASKELL_CABAL_VERSION) \
 	-t hs-static-bin:ghc-$(HASKELL_GHC_VERSION) docker/
+
+pull-image:
+	docker pull ghcr.io/michelboucey/hs-static-bin:ghc-$(HASKELL_GHC_VERSION)
+	docker image tag ghcr.io/michelboucey/hs-static-bin:ghc-$(HASKELL_GHC_VERSION) hs-static-bin:ghc-$(HASKELL_GHC_VERSION)
 
 show-env-vars:
 	@echo "HASKELL_CABAL_VERSION=$(HASKELL_CABAL_VERSION)"
@@ -59,3 +64,12 @@ docker-clean: docker-clean-containers
 	@echo $(shell docker images | grep -P hs-static-bin\\s*ghc-$$HASKELL_GHC_VERSION | awk '{print $$3}' | uniq) | xargs -r docker rmi
 
 clean-all: clean docker-clean
+
+#
+# Github hs-static-bin maintenance targets
+#
+build-push:
+	@packages/$@
+
+build-push-all:
+	@packages/$@

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ export HASKELL_GIT_REPO_URL
 help:
 	@echo "Usage:"
 	@echo
-	@echo "   image            Build hs-static-bin Docker image"
-	@echo "   pull-image       Get pre-built hs-static-bin Docker image"
 	@echo "   show-env-vars    Show hs-static-bin environment variables settings"
 	@echo "   envrc            Create a .envrc for hs-static-bin environment variables"
+	@echo "   image            Build hs-static-bin Docker image"
+	@echo "   pull-image       Get pre-built hs-static-bin Docker image"
 	@echo "   binary           Build an Haskell static binary"
 	@echo "   clean            Remove static-bin/ where Haskell binary artifacts are delivered"
 	@echo "   docker-clean     Remove hs-static-bin image and containers from Docker"

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -53,7 +53,7 @@ HASKELL_GIT_REPO_URL=https://github.com/ndmitchell/ghcid
 
 ### 3.3. Create a hs-static-bin .envrc file
 
-Based upon the `hs-static-bin` env vars currently exported, one can create a corresponding `.envrc` file.
+_Optionally_, based upon the `hs-static-bin` env vars currently exported, one can create a corresponding `.envrc` file.
 
 ```
 [user@box hs-static-bin] $ make envrc
@@ -63,17 +63,30 @@ export HASKELL_GHC_VERSION=9.8.2
 export HASKELL_GIT_REPO_URL=https://github.com/ndmitchell/ghcid
 ```
 
-## 4. Launch the Docker image build
+## 4. Get hs-static-bin Docker image
+
+- You can build by yourself this Docker image or pull a pre-built one.
+- `hs-static-bin` Docker images are tagged with the GHC version embedded, like `hs-static-bin:ghc-9.8.2`
+- You won't need to login into `hs-static-bin` containers. They normally stop on `exit 0` and cleared just after from Docker
+
+### 4.1. Get a pre-built hs-static-bin Docker image
+
+Get the pre-built `hs-static-bin` Docker image you need from [hs-static-bin package](https://github.com/MichelBoucey/hs-static-bin/pkgs/container/hs-static-bin).
+
+```
+[user@box hs-static-bin] $ make pull-image
+```
+
+_N.B._: if the `hs-static-bin` Docker image you need is missing, [open an issue](https://github.com/MichelBoucey/hs-static-bin/issues).
+
+### 4.2. Build hs-static-bin Docker image
+
+- [Docker CLI plugin buildx](https://github.com/docker/buildx) is needed
+- A single build is enough for the intended usage
 
 ```
 [user@box hs-static-bin] $ make image
 ```
-
-_N.B._ :
-- [Docker CLI plugin buildx](https://github.com/docker/buildx) is needed
-- `hs-static-bin` Docker images are tagged with the GHC version embedded, like `hs-static-bin:ghc-9.8.2`
-- A single build is enough for the intended usage
-- You won't need to login into `hs-static-bin` containers. They normally stop on `exit 0` and cleared just after from Docker
 
 ## 5. Launch the Haskell binary artifact build
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -10,9 +10,10 @@ The goal of `hs-static-bin` is to build easily `Haskell static binaries` through
 [user@box ~] $ make
 Usage:
 
-   image            Build hs-static-bin Docker image
    show-env-vars    Show hs-static-bin environment variables settings
    envrc            Create a .envrc for hs-static-bin environment variables
+   image            Build hs-static-bin Docker image
+   pull-image       Get pre-built hs-static-bin Docker image
    binary           Build an Haskell static binary
    clean            Remove static-bin/ where Haskell binary artifacts are delivered
    docker-clean     Remove hs-static-bin image and containers from Docker

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -115,7 +115,7 @@ _N.B._: Cleans only objects with the current GHC version tag.
 
 - Clone this repo
 - Set properly and export `HASKELL_CABAL_VERSION`, `HASKELL_GHC_VERSION` and `HASKELL_GIT_REPO_URL`
-- Run `make image`
+- Run `make pull-image` or `make image`
 - Run `make binary`
 - Run `ldd` against the just-built binary artifact delivered in `static-bin/` to check and ensure that it has no library dependencies.
 - Run the just-built binary artifact to check that the command is usable.

--- a/packages/build-push
+++ b/packages/build-push
@@ -1,0 +1,17 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+
+print "Building and pushing ghcr.io/michelboucey/hs-static-bin:ghc-$ENV{HASKELL_GHC_VERSION}\n";
+
+print "HASKELL_CABAL_VERSION=3.16.0.0 HASKELL_GHC_VERSION=$ENV{HASKELL_GHC_VERSION} make image\n";
+system("HASKELL_CABAL_VERSION=3.16.0.0 HASKELL_GHC_VERSION=$ENV{HASKELL_GHC_VERSION} make image");
+
+print "docker image tag hs-static-bin:ghc-$ENV{HASKELL_GHC_VERSION} ghcr.io/michelboucey/hs-static-bin:ghc-$ENV{HASKELL_GHC_VERSION}\n";
+system("docker image tag hs-static-bin:ghc-$ENV{HASKELL_GHC_VERSION} ghcr.io/michelboucey/hs-static-bin:ghc-$ENV{HASKELL_GHC_VERSION}");
+
+print "docker push ghcr.io/michelboucey/hs-static-bin:ghc-$ENV{HASKELL_GHC_VERSION}\n";
+system("docker push ghcr.io/michelboucey/hs-static-bin:ghc-$ENV{HASKELL_GHC_VERSION}");
+
+print "\n";

--- a/packages/build-push
+++ b/packages/build-push
@@ -3,6 +3,13 @@
 use warnings;
 use strict;
 
+if ($ENV{HASKELL_GHC_VERSION} eq "") {
+
+  print("HASKELL_GHC_VERSION have to be set\n");
+  exit 0;
+
+}
+
 my $CABAL_VERSION = "3.16.0.0";
 my $GHC_VERSION = $ENV{HASKELL_GHC_VERSION};
 

--- a/packages/build-push
+++ b/packages/build-push
@@ -3,15 +3,21 @@
 use warnings;
 use strict;
 
-print "Building and pushing ghcr.io/michelboucey/hs-static-bin:ghc-$ENV{HASKELL_GHC_VERSION}\n";
+my $CABAL_VERSION = "3.16.0.0";
+my $GHC_VERSION = $ENV{HASKELL_GHC_VERSION};
 
-print "HASKELL_CABAL_VERSION=3.16.0.0 HASKELL_GHC_VERSION=$ENV{HASKELL_GHC_VERSION} make image\n";
-system("HASKELL_CABAL_VERSION=3.16.0.0 HASKELL_GHC_VERSION=$ENV{HASKELL_GHC_VERSION} make image");
+print "Building and pushing ghcr.io/michelboucey/hs-static-bin:ghc-$GHC_VERSION\n";
 
-print "docker image tag hs-static-bin:ghc-$ENV{HASKELL_GHC_VERSION} ghcr.io/michelboucey/hs-static-bin:ghc-$ENV{HASKELL_GHC_VERSION}\n";
-system("docker image tag hs-static-bin:ghc-$ENV{HASKELL_GHC_VERSION} ghcr.io/michelboucey/hs-static-bin:ghc-$ENV{HASKELL_GHC_VERSION}");
+my $make_image = "HASKELL_CABAL_VERSION=$CABAL_VERSION HASKELL_GHC_VERSION=$GHC_VERSION make image";
+print $make_image."\n";
+system($make_image);
 
-print "docker push ghcr.io/michelboucey/hs-static-bin:ghc-$ENV{HASKELL_GHC_VERSION}\n";
-system("docker push ghcr.io/michelboucey/hs-static-bin:ghc-$ENV{HASKELL_GHC_VERSION}");
+my $docker_image_tag = "docker image tag hs-static-bin:ghc-$GHC_VERSION ghcr.io/michelboucey/hs-static-bin:ghc-$GHC_VERSION}";
+print $docker_image_tag."\n";
+system($docker_image_tag);
+
+my $docker_push = "docker push ghcr.io/michelboucey/hs-static-bin:ghc-$GHC_VERSION}";
+print $docker_push."\n";
+system($docker_push);
 
 print "\n";

--- a/packages/build-push-all
+++ b/packages/build-push-all
@@ -9,6 +9,8 @@ for (@versions) {
 
   chop $_;
 
-  system("HASKELL_GHC_VERSION=$_ ./build-push");
+  if ($_ eq "9.10.2") {
+  system("HASKELL_GHC_VERSION=$_ packages/build-push");
+  }
 
 }

--- a/packages/build-push-all
+++ b/packages/build-push-all
@@ -3,14 +3,12 @@
 use warnings;
 use strict;
 
-my @versions=(`ghcup list -r -o | grep -Po '^ghc\\s[\\d.]+' | sed 's/ghc\\s*//g'`);
+my @versions=(`ghcup list -r -o | grep -Po '(?<=^ghc )([\\d.]+)'`);
 
 for (@versions) {
 
   chop $_;
 
-  if ($_ eq "9.10.2") {
   system("HASKELL_GHC_VERSION=$_ packages/build-push");
-  }
 
 }

--- a/packages/build-push-all
+++ b/packages/build-push-all
@@ -1,0 +1,14 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+
+my @versions=(`ghcup list -r -o | grep -Po '^ghc\\s[\\d.]+' | sed 's/ghc\\s*//g'`);
+
+for (@versions) {
+
+  chop $_;
+
+  system("HASKELL_GHC_VERSION=$_ ./build-push");
+
+}


### PR DESCRIPTION
- Created build-push* scripts for maintenance only
- Added `hs-static-bin` Package and populated with all GHC versions supported by GHCup
- Added Makefile target `pull-image`
- `ReadMe` updated